### PR TITLE
Relative paths fixes in htmltestlogger resource files to use forward slashes instead of backward slashes

### DIFF
--- a/src/htmltestlogger/Resources/functions.js
+++ b/src/htmltestlogger/Resources/functions.js
@@ -76,7 +76,7 @@ function CreateOneCase(id)
 function ClickChange(caseDiv, casename)
 {
     // Change src dynamically
-    document.getElementById("testcase").src = 'Html\\' + casename + '.html';
+    document.getElementById("testcase").src = 'Html/' + casename + '.html';
 
     document.getElementById('back_to_summary').style.display = '';
     document.getElementById('summary').style.display = '';

--- a/src/htmltestlogger/Resources/index.html
+++ b/src/htmltestlogger/Resources/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
 
@@ -134,7 +134,7 @@ img.result{
     <div id="list">
     </div>
 
-    <script type="text/javascript" src="js\functions.js"></script>
+    <script type="text/javascript" src="./js/functions.js"></script>
 
     <script language="javascript" type="text/javascript">
         // listObj and summaryObj will be inserted above when cases are running.

--- a/src/htmltestlogger/Resources/testcase.html
+++ b/src/htmltestlogger/Resources/testcase.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -71,7 +71,7 @@ img.small{
     <div id="log">
     </div>
 </body>
-    <script type="text/javascript" src="..\js\functions.js"></script>
+    <script type="text/javascript" src="../js/functions.js"></script>
 
     <script language="javascript" type="text/javascript">
         // detailObj will be inserted above when cases are running


### PR DESCRIPTION
old browser not able to handle backslashes in relative paths given in html and java script files.
Updated them to use forward slash.